### PR TITLE
Copy realm after allocation decode

### DIFF
--- a/client_allocation.go
+++ b/client_allocation.go
@@ -117,6 +117,7 @@ func (c *Client) Allocate() (*Allocation, error) {
 	if err := c.realm.GetFrom(res); err != nil {
 		return nil, err
 	}
+	c.realm = append([]byte(nil), c.realm...)
 	c.integrity = stun.NewLongTermIntegrity(
 		c.username.String(), c.realm.String(), c.password,
 	)


### PR DESCRIPTION
After decode we would take realm by reference,
when creating permissions we would then fail
MessageIntegrity checks because this value would
be corrupted

Resolves #5
